### PR TITLE
Potential fix for code scanning alert no. 1: Server-side request forgery

### DIFF
--- a/app/api/metadata/proxy/route.ts
+++ b/app/api/metadata/proxy/route.ts
@@ -42,6 +42,15 @@ export async function GET(request: Request, { params: _params }: Params) {
 
         const parsedUrl = new URL(uriParam);
 
+        // Define an allow-list of permitted hostnames
+        const ALLOWED_HOSTNAMES = ['example.com', 'api.example.com'];
+
+        // Validate hostname against the allow-list
+        if (!ALLOWED_HOSTNAMES.includes(parsedUrl.hostname)) {
+            Logger.error(new Error('Hostname not allowed'), parsedUrl.hostname);
+            return respondWithError(403, 'Hostname not allowed');
+        }
+
         // check that uri has supported protocol despite of any other checks
         if (!isHTTPProtocol(parsedUrl)) {
             Logger.error(new Error('Unsupported protocol'), parsedUrl.protocol);


### PR DESCRIPTION
Potential fix for [https://github.com/Ori888-ux/explorer/security/code-scanning/1](https://github.com/Ori888-ux/explorer/security/code-scanning/1)

To fix the SSRF vulnerability, we need to validate and restrict the `uri` parameter to ensure it only points to allowed, safe destinations. This can be achieved by implementing an allow-list of permitted hostnames or domains and verifying that the `uri` parameter matches one of these allowed values. Additionally, we should ensure that the `uri` does not contain path traversal sequences or other malicious constructs.

**Steps to fix:**
1. Define an allow-list of permitted hostnames or domains.
2. Validate the `uri` parameter against this allow-list in `route.ts` before passing it to `fetchResource`.
3. Reject any `uri` that does not match the allow-list with an appropriate error response.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Validate and restrict requested URIs in the metadata proxy route to prevent SSRF attacks

Bug Fixes:
- Add an allow-list of permitted hostnames and reject requests to disallowed hosts with a 403 error

Enhancements:
- Log disallowed hostname errors for improved observability